### PR TITLE
typo fix

### DIFF
--- a/lua_encoders/opentsdb_http.lua
+++ b/lua_encoders/opentsdb_http.lua
@@ -114,7 +114,7 @@ function process_message()
   end
 
   if not seen_hosttag and add_hostname then
-    msg.tags["host"] = read_message("Hostame")
+    msg.tags["host"] = read_message("Hostname")
   end
 
   -- add message to buffer


### PR DESCRIPTION
There is a typo in Heka field which prevents the plugin from extracting Hostnames from Heka messages.
